### PR TITLE
filter out garbage files

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,10 @@ function getShapeFiles(zf) {
 
   // Find .shp files
   var shapefileName = filenames.filter(function(filename) {
-    if (path.extname(filename) === '.shp' && filename.indexOf("__MACOSX") === -1) return filename;
+    var accept = true;
+    if (path.extname(filename) !== '.shp') accept = false;
+    if (/__MACOSX/.test(filename)) accept = false;
+    return accept;
   });
 
   // Must contain exactly one .shp file


### PR DESCRIPTION
Zipped shapefiles were getting caught on `__MACOSX` files

@rclark 
