### PR TITLE
Use tap to generate test coverage, fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "I put a zipfile under my pillow and the shapefile-fairy brought me shapefiles",
   "main": "index.js",
   "scripts": {
-    "test": "node test"
+    "test": "tap --coverage test"
   },
   "bin": {
     "shapefile-fairy": "bin/shapefile-fairy.js"
@@ -26,6 +26,6 @@
     "zipfile": "^0.5.5"
   },
   "devDependencies": {
-    "tape": "^3.0.1"
+    "tap": "^2.3.1"
   }
 }


### PR DESCRIPTION
There was an error that `tape` wasn't catching - calling `t.end()` multiple times - and this uses `tap` to provide coverage, which is already pretty good (yay!).